### PR TITLE
Alteração api versão 4.0

### DIFF
--- a/ack_zabbix_otrs.py
+++ b/ack_zabbix_otrs.py
@@ -16,6 +16,8 @@ password = "zabbix"
 zapi = ZabbixAPI(server = server)
 zapi.login(username, password)
 
-zapi.event.acknowledge({"eventids": sys.argv[1], "message": "Ticket " + str(sys.argv[2]) + " criado no OTRS."})
+
+zapi.event.acknowledge({"eventids": sys.argv[1], "message": "Ticket " + str(sys.argv[2]) + " criado no OTRS.", "action": 4})
+zapi.event.acknowledge({"eventids": sys.argv[1], "action": 2})
 
 


### PR DESCRIPTION
https://www.zabbix.com/documentation/4.0/manual/api/reference/event/acknowledge
De acordo com a documentação nova, o campo action é necessário para gerar a mensagem, além disso, pelo que notei, ao usar a ação de reconhecer o evento, a mensagem não acompanha, por conta disso no meu cenário eu adicionei mais uma linha com a outra action.